### PR TITLE
Adding conventional `npm start` command to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Twilio&nbsp;Phone&nbsp;# | A Twilio phone number in [E.164 format](https://en.wi
     npm install
     ```
 
-4. Now we should be all set! Run the application using the `node` command.
+4. Now we should be all set! Run the application using `npm`.
 
     ```bash
-    node .
+    npm start
     ```
     
     Your application should now be running at http://localhost:3000.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "client-quickstart-node",
+  "private": true,
   "version": "1.0.0",
   "description": "Quick Start application template for Twilio Client on Node.js",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
It's common node practice to have a start script, which is special to
npm because it allows you to run `npm start` which is the usual way to
run an application.

This also adds the config flag "private": true which prevents the
package from being published to npm by accident. This could prevent the
unlikely case that someone accidentally publishes their api keys