### PR TITLE
Corrects voice response

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -33,10 +33,10 @@ exports.voiceResponse = function voiceResponse(toNumber) {
     // if is a valid phone number
     const attr = isAValidPhoneNumber(toNumber) ? 'number' : 'client';
 
-    twiml.dial({
-      [attr]: toNumber,
+    const dial = twiml.dial({
       callerId: config.callerId,
     });
+    dial[attr]({}, toNumber);
   } else {
     twiml.say('Thanks for calling!');
   }

--- a/tests/handler.test.js
+++ b/tests/handler.test.js
@@ -35,10 +35,11 @@ describe('#voiceResponse', () => {
       const count = countWord(twiml);
 
       // TwiML Verbs
-      expect(count('Dial')).toBe(1);
+      expect(count('Dial')).toBe(2);
+      expect(count('Client')).toBe(2);
 
       // TwiML options
-      expect(twiml).toContain(`client="${toNumber}"`);
+      expect(twiml).toContain(toNumber);
     });
   });
 
@@ -49,10 +50,11 @@ describe('#voiceResponse', () => {
       const count = countWord(twiml);
 
       // TwiML Verbs
-      expect(count('Dial')).toBe(1);
+      expect(count('Dial')).toBe(2);
+      expect(count('Number')).toBe(2);
 
       // TwiML options
-      expect(twiml).toContain(`number="${toNumber}"`);
+      expect(twiml).toContain(toNumber);
     });
   });
 });


### PR DESCRIPTION
When creating a `<Dial>` with Node, using

```
const twiml = new VoiceResponse();
if(toNumber) {
const attr = isAValidPhoneNumber(toNumber) ? 'number' : 'client';
const dial = twiml.dial({
  [attr]: toNumber,
  callerId: config.callerId,
});
```

Will just set an attribute on the TwiML ([as seen in the comments in this SO question](stackoverflow.com/questions/44054186/cannot-make-outbound-call-using-twilio-client-quickstart-starter-app/44069260?noredirect=1)]. That is, if it is a number, the TwiML looks like:

```
<?xml version="1.0" encoding="UTF-8"?>
<Response>
  <Dial number="+12345678901" callerId="+12345678902"/>
</Response>
```

Updating it to call the `[attr]` method on the `dial` element means we either call `dial.number` or `dial.client` and produce the expected TwiML.